### PR TITLE
Add `delete()` for RAID-1 configurations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="html"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/RaidOneAdapter.php
+++ b/src/RaidOneAdapter.php
@@ -109,6 +109,9 @@ class RaidOneAdapter extends AbstractAdapter
 	 */
 	public function update($path, $contents, Config $config)
 	{
+		/*
+		 * TODO Actually use $this->read() instead
+		 */
 		$originalContents = $this->fileSystems[0]->read($path);
 		$trueResults = 0;
 
@@ -143,6 +146,9 @@ class RaidOneAdapter extends AbstractAdapter
 	 */
 	public function updateStream($path, $resource, Config $config)
 	{
+		/*
+		 * TODO Actually use $this->read() instead
+		 */
 		$originalContents = $this->fileSystems[0]->read($path);
 		$position = ftell($resource);
 		$trueResults = 0;
@@ -209,7 +215,30 @@ class RaidOneAdapter extends AbstractAdapter
 	 */
 	public function delete($path)
 	{
-		// TODO: Implement delete() method.
+		/*
+		 * TODO Actually use $this->read() instead
+		 */
+		$originalContents = $this->fileSystems[0]->read($path);
+		$trueResults = 0;
+
+		foreach($this->fileSystems as $fileSystem) {
+			$result = $fileSystem->delete($path);
+			if($result)
+				$trueResults++;
+			else
+				break;
+		}
+
+		if($trueResults < count($this->fileSystems)) {
+			foreach($this->fileSystems as $fileSystem) {
+				if(!$fileSystem->has($path)) {
+					$fileSystem->write($path, $originalContents);
+				}
+			}
+
+			return FALSE;
+		} else
+			return TRUE;
 	}
 
 	/**

--- a/tests/RaidOneAdapterTest.php
+++ b/tests/RaidOneAdapterTest.php
@@ -291,6 +291,54 @@ class RaidOneAdapterTest extends TestCase
 
 	#endregion
 
+	#region Public Delete Tests
+
+	/**
+	 * @test
+	 */
+	public function itCanDeleteAFile()
+	{
+		$this->adapter->write('itCanDeleteAFile.txt',
+			'The quick brown fox jumps over the lazy dog.', new Config());
+
+		$result = $this->adapter->delete('itCanDeleteAFile.txt');
+
+		$this->assertTrue($result);
+		$this->assertFileNotExists('./tests/disk1/itCanDeleteAFile.txt');
+		$this->assertFileNotExists('./tests/disk2/itCanDeleteAFile.txt');
+	}
+
+	/**
+	 * @test
+	 */
+	public function itCannotDeleteAFile()
+	{
+		$this->adapter->write('itCanDeleteAFile.txt',
+			'The quick brown fox jumps over the lazy dog.', new Config());
+
+		chmod('./tests/disk2', 0544);
+		$previousErrorReporting = error_reporting(E_ERROR);
+
+		$result = $this->adapter->delete('itCanDeleteAFile.txt');
+
+		$this->assertFalse($result);
+		$this->assertFileExists('./tests/disk1/itCanDeleteAFile.txt');
+		$this->assertFileExists('./tests/disk2/itCanDeleteAFile.txt');
+		$this->assertSame(
+			file_get_contents('./tests/disk1/itCanDeleteAFile.txt'),
+			'The quick brown fox jumps over the lazy dog.'
+		);
+		$this->assertSame(
+			file_get_contents('./tests/disk2/itCanDeleteAFile.txt'),
+			'The quick brown fox jumps over the lazy dog.'
+		);
+
+		error_reporting($previousErrorReporting);
+		chmod('./tests/disk2', 0755);
+	}
+
+	#endregion
+
 	#region Protected Attributes
 
 	/**


### PR DESCRIPTION
* Implement `delete()` method in a RAID-1 fashion: The delete operation must succeed on all configured mirrors before a TRUE value is returned. If one delete operation fails, the file and its original contents are restored.
* Testing that the delete operation works
* Testing that the delete operation restores files in case of a failure
* Automatically generating HTML Code Coverage report